### PR TITLE
Allow use with Zend Framework 2.1-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zendframework": "2.0.x"
+        "zendframework/zendframework": "2.*"
     },
 
     "require-dev": {


### PR DESCRIPTION
Change zf2 requirement from 2.0.x to 2.*. There are a lot of features in ZF 2.1 I'm hoping to use and since that will be released before I finish my app, I'm using the dev branch during development. This constraint is preventing me from being able to use this module.
