### PR TITLE
Allow user to add specific parameters to be ignored when checking isActive

### DIFF
--- a/src/SpiffyNavigation/Service/Navigation.php
+++ b/src/SpiffyNavigation/Service/Navigation.php
@@ -142,8 +142,12 @@ class Navigation implements EventManagerAwareInterface
                     $page->getOption('params') ? $page->getOption('params') : array(),
                     $page->getOption('query_params') ? $page->getOption('query_params') : array()
                 );
+	            $ignoreParams = array_merge(
+		            array('__CONTROLLER__', '__NAMESPACE__', 'controller', 'action'),
+		            $page->getOption('ignore_params') ? $page->getOption('ignore_params') : array()
+	            );
 
-                $active = $this->paramsAreEqual($pageParams, $reqParams);
+                $active = $this->paramsAreEqual($pageParams, $reqParams, $ignoreParams);
             } elseif ($this->getIsActiveRecursion()) {
                 $iterator = new RecursiveIteratorIterator($page, RecursiveIteratorIterator::CHILD_FIRST);
 
@@ -341,14 +345,15 @@ class Navigation implements EventManagerAwareInterface
         return $this->isActiveRecursion;
     }
 
-    /**
-     * @param $pageParams
-     * @param $requiredParams
-     * @return bool
-     */
-    protected function paramsAreEqual($pageParams, $requiredParams)
+	/**
+	 * @param $pageParams
+	 * @param $requiredParams
+	 * @param $ignoreParams
+	 * @return bool
+	 */
+    protected function paramsAreEqual($pageParams, $requiredParams, $ignoreParams)
     {
-        foreach (array('__CONTROLLER__', '__NAMESPACE__', 'controller', 'action') as $unsetKey) {
+        foreach ($ignoreParams as $unsetKey) {
             if (isset($requiredParams[$unsetKey])) {
                 unset($requiredParams[$unsetKey]);
             }

--- a/test/SpiffyNavigationTest/Service/NavigationTest.php
+++ b/test/SpiffyNavigationTest/Service/NavigationTest.php
@@ -7,6 +7,7 @@ use SpiffyNavigation\Listener\RbacListener;
 use SpiffyNavigationTest\AbstractTest;
 use SpiffyNavigation\Page\Page;
 use SpiffyNavigation\Service\Navigation;
+use Zend\Mvc\Router\Http\Segment;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\Http\Literal;
 use Zend\Mvc\Router\Http\TreeRouteStack;
@@ -98,6 +99,48 @@ class NavigationTest extends AbstractTest
 
         $this->assertTrue($navigation->isActive($page));
         $this->assertTrue($navigation->isActive($child));
+    }
+
+    public function testIsActiveWithIgnoringParamRecursion()
+    {
+        $routeMatch = new RouteMatch(array('id' => 42));
+        $routeMatch->setMatchedRouteName('test');
+
+        $router = new TreeRouteStack();
+        $router->addRoute('test', new Segment('/foo-bar', array('id' => '[0-9]*')));
+
+        $child = new Page();
+        $child->setOptions(array('route' => 'test', 'ignore_params' => array('id')));
+
+        $page = new Page();
+        $page->addChild($child);
+
+        $navigation = new Navigation();
+        $navigation->setRouteMatch($routeMatch);
+
+        $this->assertTrue($navigation->isActive($page));
+        $this->assertTrue($navigation->isActive($child));
+    }
+
+    public function testIsActiveWithoutIgnoringParamRecursion()
+    {
+        $routeMatch = new RouteMatch(array('id' => 42));
+        $routeMatch->setMatchedRouteName('test');
+
+        $router = new TreeRouteStack();
+        $router->addRoute('test', new Segment('/foo-bar', array('id' => '[0-9]*')));
+
+        $child = new Page();
+        $child->setOptions(array('route' => 'test'));
+
+        $page = new Page();
+        $page->addChild($child);
+
+        $navigation = new Navigation();
+        $navigation->setRouteMatch($routeMatch);
+
+        $this->assertFalse($navigation->isActive($page));
+        $this->assertFalse($navigation->isActive($child));
     }
 
     public function testIsActiveWithRecursionDisabled()


### PR DESCRIPTION
A normal CRUD interface has some kind of id for editing it's ressource.

Now if you have a route called `foo/edit` for the route of the editing resource you will also need some kind of id for specifying the element. 

However if you have a navigation item for the whole `foo` resource and you want to indicate that the user is still within this part of the website you need a way to ignore the `id` parameter.

In this Pull Request i just added the option `ignore_params` within the normal options of the page letting the user add as many parameters as wished.

I also added two unittests, one without setting the parameter so see that it returns false for isActive, and one working example.

Example of a config:

```
array(
    'options' => array(
        'label' => 'Edit Customer',
        'route' => 'customers/edit',
        'ignore_params' => array('id'),
    ),
),
```
