### PR TITLE
Implement Ordering like in Zend Navigation

### DIFF
--- a/src/SpiffyNavigation/Container.php
+++ b/src/SpiffyNavigation/Container.php
@@ -18,7 +18,7 @@ class Container implements RecursiveIterator
 
     /**
      * Array of child nodes.
-     * @var array
+     * @var array|Page[]
      */
     protected $children = array();
 
@@ -87,11 +87,44 @@ class Container implements RecursiveIterator
      */
     public function addPage(Page $page)
     {
-        $this->children[] = $page;
+        $this->insertChild($page);
         return $this;
     }
 
-    /**
+	/**
+	 * Inserts a page dependend on it's order
+	 *
+	 * @param Page $page
+	 */
+	protected function insertChild(Page $page)
+	{
+		$order = (int) $page->getOption('order');
+
+		// always first, depends on the zf2 module order
+		if ($order == -1) {
+			array_unshift($this->children, $page);
+			return;
+		}
+
+		// insert
+		$size = count($this->children);
+		foreach ($this->children as $position => $child) {
+			$childOrder = (int) $child->getOption('order');
+			if ($childOrder <= $order) {
+				continue;
+			}
+
+			$children = array_slice($this->children, 0, $position);
+			array_push($children, $page);
+			$this->children = array_merge($children, array_slice($this->children, $position, $size));
+			return;
+		}
+
+		// last option, just add
+		$this->children[] = $page;
+	}
+
+	/**
      * @deprecated
      * @param string $name
      * @return Page|null

--- a/src/SpiffyNavigation/Page/Page.php
+++ b/src/SpiffyNavigation/Page/Page.php
@@ -42,7 +42,7 @@ class Page extends Container
         }
 
         $pageOrSpec->setParent($this);
-        $this->children[] = $pageOrSpec;
+	    $this->insertChild($pageOrSpec);
 
         return $this;
     }

--- a/test/SpiffyNavigationTest/AbstractTest.php
+++ b/test/SpiffyNavigationTest/AbstractTest.php
@@ -39,6 +39,11 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
     protected $container3;
 
     /**
+     * @var \SpiffyNavigation\Container
+     */
+    protected $container4;
+
+    /**
      * @var ServiceManager
      */
     protected $serviceManager;
@@ -57,10 +62,12 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
         $this->container1 = ContainerFactory::create(include __DIR__ . '/_files/config/container1.php');
         $this->container2 = ContainerFactory::create(include __DIR__ . '/_files/config/container2.php');
         $this->container3 = ContainerFactory::create(include __DIR__ . '/_files/config/container3.php');
+        $this->container4 = ContainerFactory::create(include __DIR__ . '/_files/config/container4.php');
 
         $this->nav->addContainer('container1', $this->container1);
         $this->nav->addContainer('container2', $this->container2);
         $this->nav->addContainer('container3', $this->container3);
+        $this->nav->addContainer('container4', $this->container4);
 
         // setup view
         $view = new PhpRenderer();

--- a/test/SpiffyNavigationTest/Service/NavigationTest.php
+++ b/test/SpiffyNavigationTest/Service/NavigationTest.php
@@ -196,7 +196,7 @@ class NavigationTest extends AbstractTest
         $nav->removeContainer('container1');
 
         $containers = $nav->getContainers();
-        $this->assertCount(2, $containers);
+        $this->assertCount(3, $containers);
         $this->assertEquals($this->container2, $containers['container2']);
     }
 

--- a/test/SpiffyNavigationTest/View/Helper/NavigationMenuTest.php
+++ b/test/SpiffyNavigationTest/View/Helper/NavigationMenuTest.php
@@ -25,6 +25,11 @@ class NavigationMenuTest extends AbstractTest
         $this->assertEquals($this->asset('expected/menu1.html'), $this->helper->renderMenu('container1'));
     }
 
+    public function testRenderMenuOrdering()
+    {
+        $this->assertEquals($this->asset('expected/menu4.html'), $this->helper->renderMenu('container4'));
+    }
+
     public function testIsAllowedRbac()
     {
         $rbac = new Rbac();

--- a/test/SpiffyNavigationTest/_files/config/container4.php
+++ b/test/SpiffyNavigationTest/_files/config/container4.php
@@ -1,0 +1,44 @@
+<?php
+
+return array(
+    array(
+        'options' => array(
+            'uri' => 'http://www.child1.com',
+            'name' => 'child1',
+	        'order' => 100,
+        ),
+        'attributes' => array(
+            'class' => 'child1-class',
+        ),
+    ),
+    array(
+        'options' => array(
+            'uri' => 'http://www.child1.com',
+            'name' => 'child1',
+        ),
+        'attributes' => array(
+            'class' => 'child1-2-class',
+        ),
+    ),
+    array(
+        'options' => array(
+            'uri' => 'http://www.child2.com',
+            'foo' => 'bar',
+            'name' => 'child2',
+	        'order' => -1,
+        ),
+        'attributes' => array(
+            'class' => 'child2-class',
+        )
+    ),
+    array(
+        'options' => array(
+            'uri' => 'http://www.child3.com',
+            'foo' => 'bar',
+            'name' => 'child3',
+        ),
+        'attributes' => array(
+            'class' => 'child3-class',
+        )
+    )
+);

--- a/test/SpiffyNavigationTest/_files/expected/menu4.html
+++ b/test/SpiffyNavigationTest/_files/expected/menu4.html
@@ -1,0 +1,1 @@
+<ul class="nav"><li><a class="child2-class" href="http://www.child2.com">child2</a></li><li><a class="child1-2-class" href="http://www.child1.com">child1</a></li><li><a class="child3-class" href="http://www.child3.com">child3</a></li><li><a class="child1-class" href="http://www.child1.com">child1</a></li></ul>


### PR DESCRIPTION
add option `order` to enable ordering for that page item
`-1` means always first (if two or more elements have -1 one will win)
no order option will just behave as before

Example:

```
array(
    array(
        'options' => array(
            'uri' => 'http://www.child1.com',
            'name' => 'child1',
        'order' => 100,
        ),
        'attributes' => array(
            'class' => 'child1-class',
        ),
    ),
    array(
        'options' => array(
            'uri' => 'http://www.child1.com',
            'name' => 'child1',
        ),
        'attributes' => array(
            'class' => 'child1-2-class',
        ),
    ),
    array(
        'options' => array(
            'uri' => 'http://www.child2.com',
            'foo' => 'bar',
            'name' => 'child2',
        'order' => -1,
        ),
        'attributes' => array(
            'class' => 'child2-class',
        )
    ),
    array(
        'options' => array(
            'uri' => 'http://www.child3.com',
            'foo' => 'bar',
            'name' => 'child3',
        ),
        'attributes' => array(
            'class' => 'child3-class',
        )
    )
);

```
