### PR TITLE
Correct isActive when default params are set

### DIFF
--- a/src/SpiffyNavigation/Service/Navigation.php
+++ b/src/SpiffyNavigation/Service/Navigation.php
@@ -143,7 +143,7 @@ class Navigation implements EventManagerAwareInterface
                     $page->getOption('query_params') ? $page->getOption('query_params') : array()
                 );
 
-                $active = $this->paramsAreEqual($pageParams, $reqParams);
+                $active = count(array_intersect_assoc($reqParams, $pageParams)) == count($pageParams);
             } elseif ($this->getIsActiveRecursion()) {
                 $iterator = new RecursiveIteratorIterator($page, RecursiveIteratorIterator::CHILD_FIRST);
 
@@ -339,21 +339,5 @@ class Navigation implements EventManagerAwareInterface
     public function getIsActiveRecursion()
     {
         return $this->isActiveRecursion;
-    }
-
-    /**
-     * @param $pageParams
-     * @param $requiredParams
-     * @return bool
-     */
-    protected function paramsAreEqual($pageParams, $requiredParams)
-    {
-        foreach (array('__CONTROLLER__', '__NAMESPACE__', 'controller', 'action') as $unsetKey) {
-            if (isset($requiredParams[$unsetKey])) {
-                unset($requiredParams[$unsetKey]);
-            }
-        }
-        $diff = array_diff($requiredParams, $pageParams);
-        return empty($diff);
     }
 }

--- a/test/SpiffyNavigationTest/Service/NavigationTest.php
+++ b/test/SpiffyNavigationTest/Service/NavigationTest.php
@@ -139,6 +139,24 @@ class NavigationTest extends AbstractTest
         $this->assertTrue($navigation->isActive($page));
     }
 
+    public function testIsActiveWithDefaultParam()
+    {
+        $routeMatch = new RouteMatch(array());
+        $routeMatch->setMatchedRouteName('test');
+        $routeMatch->setParam('page', 1);
+
+        $router = new TreeRouteStack();
+        $router->addRoute('test', new Literal('/foo-bar', array('page' => 1)));
+
+        $page = new Page();
+        $page->setOptions(array('route' => 'test'));
+
+        $navigation = new Navigation();
+        $navigation->setRouteMatch($routeMatch);
+
+        $this->assertTrue($navigation->isActive($page));
+    }
+
     public function testGetContainerWithInvalidNameThrowsException()
     {
         $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
I don't really understand the logic of `paramsAreEqual`.
When default parameters where set, none of my navigation was active.
The logic used in `Zend/Navigation/Page/Mvc` works fine for me.
